### PR TITLE
Refactor line chart to accept object array as data source and reduce conversion times

### DIFF
--- a/src/best-customer/story.js
+++ b/src/best-customer/story.js
@@ -311,10 +311,15 @@ export default {
 
         const measureKey = _.keys(metricsDictionary[measure])[0];
 
-        const source = [['time', measureKey]].concat(_.map(rawData, ({ timestamp, value }) =>
-          [timestamp, value]));
+        const source = _.map(rawData, ({ timestamp, value }) => ({
+          timestamp,
+          [measureKey]: value,
+        }));
 
-        return Promise.resolve({ title: '', source });
+        return Promise.resolve({
+          source,
+          axisDimensions: ['timestamp'],
+        });
       },
     },
     growthAbilityGrowthRate: {
@@ -326,10 +331,15 @@ export default {
 
         const measureKey = _.keys(metricsDictionary[measure])[0];
 
-        const source = [['time', measureKey]].concat(_.map(rawData, ({ timestamp, value }) =>
-          [timestamp, value]));
+        const source = _.map(rawData, ({ timestamp, value }) => ({
+          timestamp,
+          [measureKey]: value,
+        }));
 
-        return Promise.resolve({ title: '', source });
+        return Promise.resolve({
+          source,
+          axisDimensions: ['timestamp'],
+        });
       },
     },
   },


### PR DESCRIPTION
* Refactor line chart to accept object array as data source 
* Reduce conversion times

New interface of line component
```js
<Line value={
  source: [{
    timestamp: '2018/1/1',
    value: 10,
  }, {
    timestamp: '2018/1/2',
    value: 20,
  }],
  // Axis dimension would be drawn as X axis. 
  // Although line chart only supports 1 axis dimension, we define the prop as array for better extensibility
  axisDimensions: ['timestamp']
  // Metric dimensions prop is optional.
  // If not specified, all dimensions except axis dimensions would be used.
  metricDimensions: ['value']
}/>
```

