### PR TITLE
Refactor bar and horizontal bar to reduce conversion times

### DIFF
--- a/src/best-customer/story.js
+++ b/src/best-customer/story.js
@@ -1,6 +1,5 @@
 import Promise from 'bluebird';
 import _ from 'lodash';
-import { convertData } from '../transforms';
 import client from '../mock/worker';
 
 // dags
@@ -138,21 +137,11 @@ export default {
           return undefined;
         }
 
-        const results = _.map(data, item => [item.customerId, item.revenue]);
-        const expectedData = {
-          data: results,
-          meta: {
-            headers: ['customerId', 'revenue'],
-          },
-        };
-
-        return convertData({
-          ...expectedData,
-          groupDimensions: [],
+        return {
+          source: data,
           axisDimensions: ['customerId'],
           metricDimensions: ['revenue'],
-          serieNameTemplate: 'revenue',
-        });
+        };
       },
     },
     measureFavor: {

--- a/src/best-customer/story.js
+++ b/src/best-customer/story.js
@@ -119,21 +119,12 @@ export default {
         if (!data) {
           return undefined;
         }
-        const results = _.map(data, item => [item.revenue, item.customerId]);
-        const expectedData = {
-          data: results,
-          meta: {
-            headers: ['revenue', 'customerId'],
-          },
-        };
 
-        return convertData({
-          ...expectedData,
-          groupDimensions: [],
+        return {
+          source: data,
           axisDimensions: ['revenue'],
           metricDimensions: ['customerId'],
-          serieNameTemplate: 'customerId',
-        });
+        };
       },
     },
     fetchCustomerExpensePerUserRank: {
@@ -250,8 +241,9 @@ export default {
     usageMealCardBucketCRAP: {
       dependencies: ['fetchUsageMealCardBucketCRAP'],
       factory: data => Promise.resolve({
-        title: '',
-        source: [['name', 'value']].concat(_.map(data, item => [item.rechargeAmount, item.customerId])),
+        source: data,
+        axisDimensions: ['rechargeAmount'],
+        metricDimensions: ['customerId'],
       }),
     },
     usageMealCardQuery: {

--- a/src/components/bar.js
+++ b/src/components/bar.js
@@ -1,39 +1,36 @@
-import React, { PureComponent } from 'react';
+/* eslint-disable class-methods-use-this */
+
 import PropTypes from 'prop-types';
-import ReactEcharts from 'echarts-for-react';
 import _ from 'lodash';
-import { validate, getDimensionSeries } from '../utils';
+import BaseChart from './base';
 
-export default class Bar extends PureComponent {
-  render() {
-    const {
-      source,
-    } = this.props.value;
-    validate(source);
-    const dimensions = _.first(source);
+export default class Bar extends BaseChart {
+  getAxisOption() {
+    return {
+      data: this.getAxisData(),
+      type: 'category',
+    };
+  }
 
-    const option = {
+  getSeriesOption() {
+    const source = this.getSource();
+    return _.chain(this.getMetricDimensions())
+      .map(dim => _.defaults({
+        type: 'bar',
+        name: dim,
+        data: _.map(source, row => row[dim]),
+      }))
+      .value();
+  }
+
+  getOption() {
+    return {
       legend: {},
       tooltip: {},
-      dataset: {
-        source,
-        dimensions,
-      },
       yAxis: {},
-      xAxis: { type: 'category' },
-      series: getDimensionSeries({
-        dimensions,
-        type: 'bar',
-      }),
+      xAxis: this.getAxisOption(),
+      series: this.getSeriesOption(),
     };
-
-    return (
-      <ReactEcharts
-        option={option}
-        notMerge={true} //eslint-disable-line
-        {...this.props}
-      />
-    );
   }
 }
 

--- a/src/components/bar.js
+++ b/src/components/bar.js
@@ -1,6 +1,3 @@
-/* eslint-disable class-methods-use-this */
-
-import PropTypes from 'prop-types';
 import _ from 'lodash';
 import BaseChart from './base';
 
@@ -34,6 +31,3 @@ export default class Bar extends BaseChart {
   }
 }
 
-Bar.propTypes = {
-  value: PropTypes.objectOf(PropTypes.any).isRequired,
-};

--- a/src/components/base.js
+++ b/src/components/base.js
@@ -1,0 +1,79 @@
+/* eslint-disable class-methods-use-this */
+
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import ReactEcharts from 'echarts-for-react';
+import _ from 'lodash';
+
+
+export default class BaseChart extends PureComponent {
+  getSource() {
+    const {
+      source,
+    } = this.props.value;
+    if (_.isNil(source)) {
+      throw new Error('Chart source is nil');
+    }
+    return source;
+  }
+
+  getDimensions() {
+    return _.chain(this.getSource())
+      .first()
+      .keys()
+      .value();
+  }
+
+  getAxisDimension() {
+    return _.first(this.props.value.axisDimensions) ||
+      _.first(this.getDimensions());
+  }
+
+  getAxisData() {
+    const axisDim = this.getAxisDimension();
+    return _.chain(this.getSource())
+      .map(row => row[axisDim])
+      .value();
+  }
+
+  getAxisOption() {
+    return {
+      data: this.getAxisData(),
+      type: 'category',
+      boundaryGap: false,
+    };
+  }
+
+  getMetricDimensions() {
+    return _.isEmpty(this.props.value.metricDimensions) ?
+      _.difference(this.getDimensions(), [this.getAxisDimension()]) :
+      this.props.value.metricDimensions;
+  }
+
+  getSeriesOption() {
+    throw new Error('Unimplement BaseChart.getSeriesOption()');
+  }
+
+  getOption() {
+    throw new Error('Unimplement BaseChart.getOption()');
+  }
+
+  getEvents() {
+    return {};
+  }
+
+  render() {
+    return (
+      <ReactEcharts
+        option={this.getOption()}
+        notMerge={true} //eslint-disable-line
+        onEvents={this.getEvents()}
+        {...this.props}
+      />
+    );
+  }
+}
+
+BaseChart.propTypes = {
+  value: PropTypes.objectOf(PropTypes.any).isRequired,
+};

--- a/src/components/horizontal-bar.js
+++ b/src/components/horizontal-bar.js
@@ -1,42 +1,12 @@
-import React, { PureComponent } from 'react';
-import PropTypes from 'prop-types';
-import ReactEcharts from 'echarts-for-react';
 import _ from 'lodash';
-import { validate, getDimensionSeries } from '../utils';
+import Bar from './bar';
 
-export default class HorizontalBar extends PureComponent {
-  render() {
-    const {
-      source,
-    } = this.props.value;
-    validate(source);
-    const dimensions = _.first(source);
-    const option = {
-      legend: {},
-      tooltip: {
-        trigger: 'axis',
-        axisPointer: {
-          type: 'shadow',
-        },
-      },
-      dataset: {
-        source,
-        dimensions,
-      },
-      yAxis: { type: 'category' },
-      xAxis: { type: 'value' },
-      series: getDimensionSeries({
-        dimensions,
-        type: 'bar',
-      }),
-    };
-
-    return (
-      <ReactEcharts option={option} {...this.props} />
-    );
+export default class HorizontalBar extends Bar {
+  getOption() {
+    const rawOption = super.getOption();
+    return _.defaults({
+      xAxis: rawOption.yAxis,
+      yAxis: rawOption.xAxis,
+    }, rawOption);
   }
 }
-
-HorizontalBar.propTypes = {
-  value: PropTypes.objectOf(PropTypes.any).isRequired,
-};

--- a/src/components/line.js
+++ b/src/components/line.js
@@ -43,7 +43,6 @@ export default class Line extends BaseChart {
 }
 
 Line.propTypes = {
-  value: PropTypes.objectOf(PropTypes.any).isRequired,
   title: PropTypes.string,
   onSlicerChange: PropTypes.func,
 };

--- a/src/components/line.js
+++ b/src/components/line.js
@@ -1,51 +1,8 @@
-import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import ReactEcharts from 'echarts-for-react';
 import _ from 'lodash';
-import { validate } from '../utils';
+import BaseChart from './base';
 
-
-export default class Line extends PureComponent {
-  getSource() {
-    const {
-      source,
-    } = this.props.value;
-    return source;
-  }
-
-  getDimensions() {
-    return _.chain(this.getSource())
-      .first()
-      .keys()
-      .value();
-  }
-
-  getAxisDimension() {
-    return _.first(this.props.value.axisDimensions) ||
-      _.first(this.getDimensions());
-  }
-
-  getAxisData() {
-    const axisDim = this.getAxisDimension();
-    return _.chain(this.getSource())
-      .map(row => row[axisDim])
-      .value();
-  }
-
-  getAxisOption() {
-    return {
-      data: this.getAxisData(),
-      type: 'category',
-      boundaryGap: false,
-    };
-  }
-
-  getMetricDimensions() {
-    return _.isEmpty(this.props.value.metricDimensions) ?
-      _.difference(this.getDimensions(), [this.getAxisDimension()]) :
-      this.props.value.metricDimensions;
-  }
-
+export default class Line extends BaseChart {
   getSeriesOption() {
     const source = this.getSource();
     return _.chain(this.getMetricDimensions())
@@ -74,26 +31,14 @@ export default class Line extends PureComponent {
     });
   }
 
-  render() {
-    const source = this.getSource();
-
-    validate(source);
-    const onEvents = {
+  getEvents() {
+    return {
       click: args =>
         this.props.onSlicerChange(_.defaults(
-          {}, { dataObj: _.zipObject(_.first(source), args.data) },
+          {}, { dataObj: _.zipObject(this.getDimensions(), args.data) },
           args,
         )),
     };
-
-    return (
-      <ReactEcharts
-        option={this.getOption()}
-        notMerge={true} //eslint-disable-line
-        onEvents={onEvents}
-        {...this.props}
-      />
-    );
   }
 }
 

--- a/src/components/line.js
+++ b/src/components/line.js
@@ -2,6 +2,24 @@ import PropTypes from 'prop-types';
 import _ from 'lodash';
 import BaseChart from './base';
 
+/* Demo usage
+ <Line value={
+    source: [{
+      timestamp: '2018/1/1',
+      value: 10,
+    }, {
+      timestamp: '2018/1/2',
+      value: 20,
+    }],
+    // Axis dimension would be drawn as X axis.
+    // Although line chart only supports 1 axis dimension,
+    // we define the prop as array for better extensibility
+    axisDimensions: ['timestamp']
+    // Metric dimensions prop is optional.
+    // If not specified, all dimensions except axis dimensions would be used.
+    metricDimensions: ['value']
+  }/>
+*/
 export default class Line extends BaseChart {
   getSeriesOption() {
     const source = this.getSource();


### PR DESCRIPTION
* Create BaseChart component which is shared by Line and Bar
* Refactor bar and horizontal bar
    1. Align interface with Line chart
    2. Reduce conversion times
    3. Better code reuse, e.g. Horizontal Bar shares all logic with Bar expect swapping X and Y axis.

Demo of Bar:
```js
 <Bar value={
    source: [{
      timestamp: '2018/1/1',
      value: 10,
    }, {
      timestamp: '2018/1/2',
      value: 20,
    }],
    // Axis dimension would be drawn as X axis.
    // Although line chart only supports 1 axis dimension,
    // we define the prop as array for better extensibility
    axisDimensions: ['timestamp']
    // Metric dimensions prop is optional.
    // If not specified, all dimensions except axis dimensions would be used.
    metricDimensions: ['value']
  }/>
```